### PR TITLE
fix: use simple title when page_title is not present

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,9 @@
 module ApplicationHelper
 
+  def build_title(base, page_title)
+    [base, page_title.presence].compact.join(' - ')
+  end
+
   def formatted_minutes(minutes, options = {})
     result = "#{minutes / 60}"
     result << " #{t('entries.hours')}" if options[:legend]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,7 +1,8 @@
 doctype html
 html
   head
-    title #{t('common.tracker')} - #{yield(:title)}
+    title
+      = build_title(t('common.tracker'), yield(:title))
     meta charset="utf-8"
     meta name="author" content="eBallance Creative s.r.o."
     meta http-equiv="X-UA-Compatible" content="IE=edge"


### PR DESCRIPTION
Use "Tracker" instead of "Tracker - " as a title on some pages.